### PR TITLE
Allow reading meilisearch master key secret from file.

### DIFF
--- a/config/bonfire_search.exs
+++ b/config/bonfire_search.exs
@@ -7,7 +7,7 @@ config :bonfire_search,
   # protocol, hostname and port
   instance: System.get_env("SEARCH_MEILI_INSTANCE", "http://search:7700"),
   # secret key
-  api_key: System.get_env("MEILI_MASTER_KEY", "make-sure-to-change-me")
+  api_key: System.get_env("MEILI_MASTER_KEY") || File.read!(System.get_env("MEILI_MASTER_KEY_FILE"))
 
 # for use by API client
 # config :tesla, :adapter, {Tesla.Adapter.Finch, name: Bonfire.Finch}

--- a/lib/runtime_config.ex
+++ b/lib/runtime_config.ex
@@ -16,7 +16,7 @@ defmodule Bonfire.Search.RuntimeConfig do
       # protocol, hostname and port
       instance: System.get_env("SEARCH_MEILI_INSTANCE", "http://search:7700"),
       # secret key
-      api_key: System.get_env("MEILI_MASTER_KEY", "make-sure-to-change-me")
+      api_key: System.get_env("MEILI_MASTER_KEY") || File.read!(System.get_env("MEILI_MASTER_KEY_FILE"))
 
     config :bonfire_search, Bonfire.Search.Indexer,
       modularity:


### PR DESCRIPTION
While working on https://github.com/bonfire-networks/bonfire-nix I realized it would be easier in some cases to read secrets from files (such as the ones provisioned with https://github.com/Mic92/sops-nix or https://github.com/fishinthecalculator/sops-guix ).

In case this is the right approach, I'd like to implement the same functionality for all Bonfire's secrets ( `POSTGRES_PASSWORD`, `MAIL_PRIVATE_KEY`, `MAIL_PASSWORD` , `SECRET_KEY_BASE`, `SIGNING_SALT`, `ENCRYPTION_SALT` and possibly others I may be missing).

Probably it'd also make sense to have a shared procedure for all extensions to have the same logic of:

- trying to read a secret environment variable
- if it is defined the value from the environment is returned
- otherwise fall back to the same variable with `_FILE` suffix, read the file specified in its value as the secret content
- if the variable suffixed with `_FILE` is not set, or the file it specifies in its value does not exists or is not readable by the Bonfire process, it could return a default value (such as `"make-sure-to-change-me"`)
- otherwise throw an exception warning the user to set either of the variables

If this common logic is sound and you agree it's the right way forward, should this live in `bonfire_common` ?

Thank you :smile: 
  